### PR TITLE
Renamed artefacts and netbeans modules:

### DIFF
--- a/kg-dqp/pom.xml
+++ b/kg-dqp/pom.xml
@@ -22,7 +22,7 @@
         </dependency>
         <dependency>
             <groupId>${project.groupId}</groupId>
-            <artifactId>kgtool</artifactId>
+            <artifactId>corese-core</artifactId>
             <version>${project.version}</version>
         </dependency>
         

--- a/kgengine/pom.xml
+++ b/kgengine/pom.xml
@@ -15,7 +15,7 @@
         
         <dependency>
             <groupId>fr.inria.wimmics</groupId>
-            <artifactId>kgtool</artifactId>
+            <artifactId>corese-core</artifactId>
             <version>${project.parent.version}</version>
         </dependency>
         <dependency>

--- a/kggui/pom.xml
+++ b/kggui/pom.xml
@@ -8,7 +8,7 @@
 	</parent>
 	
 	<groupId>fr.inria.wimmics</groupId>
-	<artifactId>corese</artifactId>
+	<artifactId>corese-gui</artifactId>
 	<!--    <properties>
 	    <corese-version>3.0.7</corese-version>
 	</properties>-->
@@ -31,7 +31,7 @@
 		</dependency>
 		<dependency>
 			<groupId>fr.inria.wimmics</groupId>
-			<artifactId>kgtool</artifactId>
+			<artifactId>corese-core</artifactId>
 			<version>${project.version}</version>
 		</dependency>
 		<dependency>
@@ -182,5 +182,6 @@
 				</plugins> 
 			</build> 
 		</profile> 
-	</profiles> 
+	</profiles>
+    <name>corese-gui</name>
 </project>

--- a/kgimport/pom.xml
+++ b/kgimport/pom.xml
@@ -25,7 +25,7 @@
         </dependency>
         <dependency>
             <groupId>fr.inria.wimmics</groupId>
-            <artifactId>kgtool</artifactId>
+            <artifactId>corese-core</artifactId>
             <version>${project.version}</version>
         </dependency>
         <dependency>

--- a/kgtool/pom.xml
+++ b/kgtool/pom.xml
@@ -3,7 +3,7 @@
     <modelVersion>4.0.0</modelVersion>
     
     <groupId>fr.inria.wimmics</groupId>
-    <artifactId>kgtool</artifactId>
+    <artifactId>corese-core</artifactId>
     
     <parent>
         <groupId>fr.inria.wimmics</groupId>
@@ -210,4 +210,6 @@
 
         </plugins>
     </build>
-<profiles> <profile> <id>jenkins</id> <activation> <property> <name>env.BUILD_NUMBER</name> </property> </activation> <build> <plugins> <plugin> <groupId>org.codehaus.mojo</groupId> <artifactId>cobertura-maven-plugin</artifactId> </plugin> </plugins> </build> </profile> </profiles> </project>
+<profiles> <profile> <id>jenkins</id> <activation> <property> <name>env.BUILD_NUMBER</name> </property> </activation> <build> <plugins> <plugin> <groupId>org.codehaus.mojo</groupId> <artifactId>cobertura-maven-plugin</artifactId> </plugin> </plugins> </build> </profile> </profiles>
+    <name>corese-core</name>
+</project>


### PR DESCRIPTION
  corese to corese-gui, kgtool to corese-core, kgserver to corese-server
Note that the directories keep their old names to reflect the package they define.