### PR TITLE
Fix/issue64

### DIFF
--- a/corese-core/src/main/java/fr/inria/corese/core/load/jsonld/CoreseJsonTripleCallback.java
+++ b/corese-core/src/main/java/fr/inria/corese/core/load/jsonld/CoreseJsonTripleCallback.java
@@ -1,6 +1,6 @@
 package fr.inria.corese.core.load.jsonld;
 
-import com.github.jsonldjava.core.JSONLDTripleCallback;
+import com.github.jsonldjava.core.JsonLdTripleCallback ;
 import com.github.jsonldjava.core.RDFDataset;
 import fr.inria.corese.kgram.api.core.Node;
 import fr.inria.corese.core.Graph;
@@ -15,7 +15,7 @@ import java.util.List;
  * @author Fuqi Song, Wimmics inria i3s
  * @date 10 Feb. 2014 new
  */
-public class CoreseJsonTripleCallback implements JSONLDTripleCallback {
+public class CoreseJsonTripleCallback implements JsonLdTripleCallback {
 
     private AddTripleHelper helper;
     private Graph graph;

--- a/corese-core/src/main/java/fr/inria/corese/core/load/jsonld/JsonldLoader.java
+++ b/corese-core/src/main/java/fr/inria/corese/core/load/jsonld/JsonldLoader.java
@@ -1,6 +1,6 @@
 package fr.inria.corese.core.load.jsonld;
 
-import com.github.jsonldjava.core.JSONLDTripleCallback;
+import com.github.jsonldjava.core.JsonLdTripleCallback;
 import com.github.jsonldjava.core.JsonLdError;
 import com.github.jsonldjava.core.JsonLdProcessor;
 import com.github.jsonldjava.utils.JSONUtils;
@@ -70,7 +70,7 @@ public class JsonldLoader {
      * @throws java.io.IOException
      * @throws com.github.jsonldjava.core.JsonLdError
      */
-    public void load(JSONLDTripleCallback callback) throws IOException, JsonLdError {
+    public void load(JsonLdTripleCallback callback) throws IOException, JsonLdError {
         // resolve the "reader" to JSON objects using parser
         Object jsonObject = JSONUtils.fromReader(this.reader);
         


### PR DESCRIPTION
cc @andreiciortea

Fixed issue #64 by renaming the JsonLdTripleCallback from the jsonld library which causes a severe runtime exception when loading a corese graph (see #64 ).

I've tested it locally by building corese-core and including the jar into our project.