### PR TITLE
Removing repeated println during reasoning

### DIFF
--- a/corese-core/src/main/java/fr/inria/corese/core/api/DataBrokerConstruct.java
+++ b/corese-core/src/main/java/fr/inria/corese/core/api/DataBrokerConstruct.java
@@ -23,7 +23,7 @@ import fr.inria.corese.sparql.triple.update.Basic;
 public interface DataBrokerConstruct extends DataBroker {
 
     default void startRuleEngine() {
-        System.out.println("DataBrokerConstruct startRuleEngine");
+        // System.out.println("DataBrokerConstruct startRuleEngine");
     }
 
     default void endRuleEngine() {


### PR DESCRIPTION
"DataBrokerConstruct startRuleEngine" Appear at each query sent to a corese docker server with reasoning